### PR TITLE
Time zone handling improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Werkzeug==0.9.4
 argparse==1.2.1
 blinker==1.3
 cffi==0.8.1
-cryptography==0.2.2
+cryptography==0.6.1
 flup==1.0.2
 itsdangerous==0.23
 jsonrpclib==0.1.3

--- a/src/plugins/fedtools/delegatetools.py
+++ b/src/plugins/fedtools/delegatetools.py
@@ -308,7 +308,12 @@ class DelegateTools(object):
                 if not required_privileges or set(privileges+priv_from_cred).intersection(required_privileges):
                     cred_accepted = True
                     break
+#This would be cleaner, but I don't know what the correct way to import this is
+#            except Credential.CredentialExpireTimezoneError as e:
+#                raise GFedv2AuthorizationError("Your credentials has an invalid expire date (missing timezone info)")
             except Exception as e:
+                if (e.args[0].startswith('Invalid expire value in credential, missing timezone info')):
+                    raise GFedv2AuthorizationError("Your credentials has an invalid expire date (missing timezone info)")
                 import traceback
                 traceback.print_exc()
                 #print e

--- a/src/plugins/osliceauthorityrm/osliceauthorityresourcemanager.py
+++ b/src/plugins/osliceauthorityrm/osliceauthorityresourcemanager.py
@@ -269,7 +269,7 @@ class OSliceAuthorityResourceManager(object):
         self._validate_project_urn(p_urn)
 
         if 'PROJECT_EXPIRATION' in fields:
-            expDate = datetime.datetime.strptime(fields['PROJECT_EXPIRATION'], '%Y-%m-%dT%H:%M:%SZ')
+            expDate = datetime.datetime.strptime(fields['PROJECT_EXPIRATION'], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=pytz.utc)
             if expDate > self.CRED_EXPIRY:
                 fields['PROJECT_EXPIRATION'] = pyrfc3339.generate(self.CRED_EXPIRY.replace(tzinfo=pytz.utc))
         else:
@@ -654,7 +654,7 @@ class OSliceAuthorityResourceManager(object):
         if len(lookup_results) > 0:
 
             # Slice exists, Let's check if it has been expired
-            expDate = datetime.datetime.strptime(lookup_results[0]['SLICE_EXPIRATION'], '%Y-%m-%dT%H:%M:%SZ')
+            expDate = datetime.datetime.strptime(lookup_results[0]['SLICE_EXPIRATION'], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=pytz.utc)
             now = datetime.datetime.utcnow()
             if now < expDate:
                 raise self.gfed_ex.GFedv2DuplicateError("A slice with specified name already exists under the following URN:"+ str(slice_urn))
@@ -670,7 +670,7 @@ class OSliceAuthorityResourceManager(object):
         if len(lookup_results) > 0:
 
             # Slice exists, Let's check if it has been expired
-            expDate = datetime.datetime.strptime(lookup_results[0]['PROJECT_EXPIRATION'], '%Y-%m-%dT%H:%M:%SZ')
+            expDate = datetime.datetime.strptime(lookup_results[0]['PROJECT_EXPIRATION'], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=pytz.utc)
             now = datetime.datetime.utcnow()
             if now < expDate:
                 raise self.gfed_ex.GFedv2DuplicateError("A project with specified name already exists under the following URN:"+ str(project_urn))

--- a/src/plugins/osliceauthorityrm/osliceauthorityresourcemanager.py
+++ b/src/plugins/osliceauthorityrm/osliceauthorityresourcemanager.py
@@ -155,7 +155,7 @@ class OSliceAuthorityResourceManager(object):
         fields['SLICE_EXPIRED'] = False
 
         if 'SLICE_EXPIRATION' in fields:
-            expDate = datetime.datetime.strptime(fields['SLICE_EXPIRATION'], '%Y-%m-%dT%H:%M:%SZ')
+            expDate = datetime.datetime.strptime(fields['SLICE_EXPIRATION'], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=pytz.utc)
             if expDate > self.CRED_EXPIRY:
                 fields['SLICE_EXPIRATION'] = pyrfc3339.generate(self.CRED_EXPIRY.replace(tzinfo=pytz.utc))
         else:

--- a/src/vendor/geni_trust/ext/sfa/trust/credential.py
+++ b/src/vendor/geni_trust/ext/sfa/trust/credential.py
@@ -375,7 +375,6 @@ class Credential(object):
             self.decode()
         return self.gidObject
             
-
     ##
     # Expiration: an absolute UTC time of expiration (as either an int or string or datetime)
     # 
@@ -717,7 +716,6 @@ class Credential(object):
         self.decode()       
 
         
-
     ##
     # Retrieve the attributes of the credential from the XML.
     # This is automatically called by the various get_* methods of

--- a/src/vendor/geni_trust/ext/sfa/util/sfatime.py
+++ b/src/vendor/geni_trust/ext/sfa/util/sfatime.py
@@ -50,6 +50,9 @@ For safety this can also handle inputs that are either timestamps, or datetimes
         t = dateutil.parser.parse(input)
         if t.utcoffset() is not None:
             t = t.utcoffset() + t.replace(tzinfo=None)
+            # the above line is wrong: you need to substract the utcoffset, not add it!
+            # a better way is: t = t.astimezone(pytz.utc)   #only works if not naive 
+            raise RuntimeException('unfixed bug in code triggered')
         return t
     elif isinstance (input, (int,float,long)):
         return datetime.datetime.fromtimestamp(input)

--- a/src/vendor/geniv3rpc/ext/sfa/trust/credential.py
+++ b/src/vendor/geniv3rpc/ext/sfa/trust/credential.py
@@ -34,6 +34,7 @@ from tempfile import mkstemp
 from xml.dom.minidom import Document, parseString
 import pytz
 import pyrfc3339
+import dateutil
 
 HAVELXML = False
 try:

--- a/src/vendor/geniv3rpc/ext/sfa/trust/credential.py
+++ b/src/vendor/geniv3rpc/ext/sfa/trust/credential.py
@@ -230,6 +230,11 @@ def filter_creds_by_caller(creds, caller_hrn_list):
             except: pass
         return caller_creds
 
+class ExpireTimezoneError(ValueError):
+    pass
+class CredentialExpireTimezoneError(ValueError):
+    pass
+
 class Credential(object):
 
     ##
@@ -382,6 +387,8 @@ class Credential(object):
                 raise ValueError('set_expiration called with expire time missing timezone info')
         elif isinstance (expiration, StringTypes):
             self.expiration = dateutil.parser.parse(expiration)
+            if self.expiration.tzinfo is None or self.expiration.tzinfo.utcoffset(self.expiration) is None:
+                raise ExpireTimezoneError('set_expiration callled with String expire time missing timezone info: "{0}"'.format(expiration))
         else:
             logger.error ("unexpected input type in Credential.set_expiration")
             raise ValueError('unexpected input type in Credential.set_expiration', expiration)
@@ -736,7 +743,10 @@ class Credential(object):
         cred = creds[0]
 
         self.set_refid(cred.getAttribute("xml:id"))
+        try:
         self.set_expiration(getTextNode(cred, "expires"))
+        except ExpireTimezoneError as e:
+            raise CredentialExpireTimezoneError('Invalid expire value in credential, missing timezone info: "{0}"'.format(getTextNode(cred, "expires")))
         self.gidCaller = GID(string=getTextNode(cred, "owner_gid"))
         self.gidObject = GID(string=getTextNode(cred, "target_gid"))   
 

--- a/src/vendor/geniv3rpc/ext/sfa/trust/credential.py
+++ b/src/vendor/geniv3rpc/ext/sfa/trust/credential.py
@@ -32,6 +32,8 @@ import datetime
 from StringIO import StringIO
 from tempfile import mkstemp
 from xml.dom.minidom import Document, parseString
+import pytz
+import pyrfc3339
 
 HAVELXML = False
 try:
@@ -310,7 +312,7 @@ class Credential(object):
         self.gidObject = legacy.get_gid_object()
         lifetime = legacy.get_lifetime()
         if not lifetime:
-            self.set_expiration(datetime.datetime.utcnow() + datetime.timedelta(seconds=DEFAULT_CREDENTIAL_LIFETIME))
+            self.set_expiration((datetime.datetime.utcnow() + datetime.timedelta(seconds=DEFAULT_CREDENTIAL_LIFETIME)).replace(tzinfo=pytz.utc))
         else:
             self.set_expiration(int(lifetime))
         self.lifeTime = legacy.get_lifetime()
@@ -372,13 +374,28 @@ class Credential(object):
     # 
     def set_expiration(self, expiration):
         if isinstance(expiration, (int, float)):
-            self.expiration = datetime.datetime.fromtimestamp(expiration)
+            self.expiration = datetime.datetime.utcfromtimestamp(expiration).replace(tzinfo=pytz.utc)
         elif isinstance (expiration, datetime.datetime):
             self.expiration = expiration
+            if self.expiration.tzinfo is None or self.expiration.tzinfo.utcoffset(self.expiration) is None:
+                raise ValueError('set_expiration called with expire time missing timezone info')
         elif isinstance (expiration, StringTypes):
-            self.expiration = utcparse (expiration)
+            self.expiration = dateutil.parser.parse(expiration)
         else:
             logger.error ("unexpected input type in Credential.set_expiration")
+            raise ValueError('unexpected input type in Credential.set_expiration', expiration)
+        
+        if not isinstance (self.expiration, datetime.datetime):
+            logger.error('credential.py bug: set_expiration finished with credential is not datetime. It is {0}'.format(self.expiration.__class__))
+            raise RuntimeError('credential.py bug: set_expiration finished with credential that is not datetime')
+        
+        if self.expiration.tzinfo is None or self.expiration.tzinfo.utcoffset(self.expiration) is None:
+            logger.error('credential.py bug: set_expiration finished with credential that has expire time missing timezone info')
+            raise RuntimeError('credential.py bug: set_expiration finished with credential that has expire time missing timezone info')
+        
+        if t.utcoffset() is not None:
+            #force timezone to UTC without changing time
+            t = t.astimezone(pytz.utc)
 
 
     ##
@@ -469,10 +486,21 @@ class Credential(object):
         append_sub(doc, cred, "target_gid", self.gidObject.save_to_string())
         append_sub(doc, cred, "target_urn", self.gidObject.get_urn())
         append_sub(doc, cred, "uuid", "")
+
+        #was: if not self.expiration:
+        #was:    self.set_expiration(datetime.datetime.utcnow() + datetime.timedelta(seconds=DEFAULT_CREDENTIAL_LIFETIME))
         if not self.expiration:
-            self.set_expiration(datetime.datetime.utcnow() + datetime.timedelta(seconds=DEFAULT_CREDENTIAL_LIFETIME))
+            logger.error('credential.py usage bug: credential was created without expire')
+            raise RuntimeError('credential.py usage bug: credential was created without expire')
+        if (not isinstance (self.expiration, datetime.datetime)) or self.expiration.tzinfo is None or self.expiration.tzinfo.utcoffset(self.expiration) is None:
+            #credential.py bug because set_expiration should have handled this
+            logger.error('credential.py bug: credential was has expire time missing timezone info')
+            raise RuntimeError('credential.py bug: credential was has expire time missing timezone info')
+        else:
         self.expiration = self.expiration.replace(microsecond=0)
-        append_sub(doc, cred, "expires", self.expiration.isoformat())
+            append_sub(doc, cred, "expires", pyrfc3339.generate(self.expiration))
+            #was: append_sub(doc, cred, "expires", self.expiration.isoformat())
+
         privileges = doc.createElement("privileges")
         cred.appendChild(privileges)
 
@@ -707,7 +735,7 @@ class Credential(object):
         cred = creds[0]
 
         self.set_refid(cred.getAttribute("xml:id"))
-        self.set_expiration(utcparse(getTextNode(cred, "expires")))
+        self.set_expiration(getTextNode(cred, "expires"))
         self.gidCaller = GID(string=getTextNode(cred, "owner_gid"))
         self.gidObject = GID(string=getTextNode(cred, "target_gid"))   
 

--- a/src/vendor/geniv3rpc/ext/sfa/util/sfatime.py
+++ b/src/vendor/geniv3rpc/ext/sfa/util/sfatime.py
@@ -50,6 +50,9 @@ For safety this can also handle inputs that are either timestamps, or datetimes
         t = dateutil.parser.parse(input)
         if t.utcoffset() is not None:
             t = t.utcoffset() + t.replace(tzinfo=None)
+            # the above line is wrong: you need to substract the utcoffset, not add it!
+            # a better way is: t = t.astimezone(pytz.utc)   #only works if not naive 
+            raise RuntimeException('unfixed bug in code triggered')
         return t
     elif isinstance (input, (int,float,long)):
         return datetime.datetime.fromtimestamp(input)


### PR DESCRIPTION
I have noticed that C-BAS in some cases returns credentials with an expiration date that is missing a timezone. This is a major bug: A client can't know if the returned date is in the UTC timezone, in the server's local timezone, or in some other timezone. It also means that the date is not valid RFC3339 (since that requires a timezone at all time). So RFC3339 date parsers might fail for such dates. The jFed client (and probably others as well) will get into trouble because of missing timezones.
In my opinion, this timezone bug is very bad and need to be fixed...

This pull request tries to fix these issues. However, I'm not sure if everything I've done is 100% correct: I'm not very experienced with python and the handling of dates in python (with naive and aware dates etc) is confusing.
Also note that some of the changes are done in "src/vendor" which means they are changes in external libraries used by C-BAS.

It would be great if you could review (and test) these changes!
